### PR TITLE
Adding optional --target-width flag to download only one video

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ You will also need [ffmpeg](https://ffmpeg.org/). Install for your operating sys
 Usage
 =====
 
-`twitter-dl.py [-hdo] VIDEO_URL`
+`twitter-dl.py [-hdow] VIDEO_URL`
 
 `-d` or `--debug`: This will enable debugging output. Additional `-d` flags (up to 2) will increase debugging.
 
 `-o` or `--output`: Change the output directory. The default is `output/`
 
-`-h`: Help.
+`-w` or `--target_width`: In pixels. Download only the video resolution closest to this value. e.g. `-w 500`
 
+`-h`: Help.
 
 Vagrant
 =======

--- a/twitter-dl.py
+++ b/twitter-dl.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
 	parser.add_argument('tweet_url', help='The video URL on Twitter (https://twitter.com/<user>/status/<id>).')
 	parser.add_argument('-o', '--output', dest='output', default='./output', help='The directory to output to. The structure will be: <output>/<user>/<id>.')
 	parser.add_argument('-d', '--debug', default=0, action='count', dest='debug', help='Debug. Add more to print out response bodies (maximum 2).')
-	parser.add_argument('-w', '--target_width', dest='target_width', default=0, help='In pixels. Download only video resolution closest to this value')
+	parser.add_argument('-w', '--target_width', dest='target_width', default=0, help='In pixels. Download only the video resolution closest to this value')
 
 	args = parser.parse_args()
 

--- a/twitter-dl.py
+++ b/twitter-dl.py
@@ -188,7 +188,7 @@ class TwitterDownloader:
 			dist_2_target = abs(instance.stream_info.resolution[0] - self.target_width)
 			if dist_2_target < min_dist_2_target:
 				min_dist_2_target = dist_2_target
-				# Replace only item of playlist with this one
+				# Replace the only item of new_playlist with this one
 				new_playlist.playlists = []
 				new_playlist.playlists.append(instance)
 
@@ -216,7 +216,7 @@ if __name__ == '__main__':
 	parser.add_argument('tweet_url', help='The video URL on Twitter (https://twitter.com/<user>/status/<id>).')
 	parser.add_argument('-o', '--output', dest='output', default='./output', help='The directory to output to. The structure will be: <output>/<user>/<id>.')
 	parser.add_argument('-d', '--debug', default=0, action='count', dest='debug', help='Debug. Add more to print out response bodies (maximum 2).')
-	parser.add_argument('-w', '--target_width', dest='target_width', default=0, help='In pixels. Download only video resolution closest to this value')
+	parser.add_argument('-w', '--target_width', dest='target_width', default=0, help='In pixels. Download only the video resolution closest to this value')
 
 	args = parser.parse_args()
 


### PR DESCRIPTION
I propose this enhancement because the download of all the available resolutions of each video can be unnecessary and time consuming (certainly for me).

By passing the argument -w 500 for example, one can download the video in the available resolutions that has its width closest to the target, e.g. 480x480 in this case. If the flag is omitted, the behavior is unchanged and all resolutions are downloaded.

The approach is to replace the `playlist` object with a copy that only includes the selected resolution in its `playlists` member. This enables the new feature with a call to `TwitterDownloader.__filter_playlist(self, playlist)` and a minimal amount of change to your code.